### PR TITLE
Fix break time not recalculating when editing shift times

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,121 @@
+# 🎨 Client Portal UI/UX Redesign
+
+## Overview
+Complete redesign of the TimeTally client portal with a modern, polished interface featuring smooth animations, glassmorphism effects, and improved user experience across all employee and manager workflows.
+
+## 📊 Summary
+- **9 files changed**: 1,181 insertions(+), 477 deletions(-)
+- **New dependency**: `framer-motion` for React animations
+- **Design system**: Consistent blue (#0066FF) color scheme with glassmorphism effects
+
+## ✨ Key Features
+
+### Design Improvements
+- **Glassmorphism UI**: Implemented backdrop blur effects throughout the application
+- **Consistent color scheme**: Applied unified blue (#0066FF) primary color across all pages
+- **Responsive design**: 
+  - Mobile-first approach for employee-facing pages
+  - Desktop-first approach for manager-facing pages
+- **Modern card designs**: Rounded corners, subtle shadows, and gradient backgrounds
+
+### Animation Enhancements
+- **Smooth transitions**: Added framer-motion for declarative, performant animations
+- **Entrance animations**: Staggered fade-in effects for list items and cards
+- **Interactive feedback**: 
+  - Hover effects with smooth vertical lift animations
+  - Icon wiggle effects on interactive elements
+  - One-time fade-out effects (replaced infinite ping animations)
+- **Performance optimizations**: 
+  - Transform-only animations to leverage GPU acceleration
+  - Removed scale transforms on text to prevent blurriness
+  - AnimatePresence for smooth mount/unmount transitions
+
+## 📄 Pages Updated
+
+### Client Landing Page (`/client`)
+- Staggered entrance animations for feature cards
+- Animated login cards with hover effects
+- Enhanced visual hierarchy and spacing
+
+### Employee Login (`/client/employee/login`)
+- PIN authentication interface with animated icons
+- Improved visual feedback for user interactions
+- Mobile-optimized layout
+
+### Employee Dashboard (`/client/employee/dashboard`)
+- Mobile-optimized timesheet entry interface
+- Touch-friendly UI components
+- Weekly view with animated day cards
+- Smooth transitions for time entry
+
+### Manager Login (`/client/manager/login`)
+- Polished authentication interface
+- Secure access with animated elements
+- Desktop-optimized layout
+
+### Manager Dashboard (`/client/manager/dashboard`)
+- Payroll overview with animated stat cards
+- Employee list with staggered entrance animations
+- Interactive hover effects on employee cards
+- Enhanced data visualization
+
+### Manager Employee Detail (`/client/manager/employee/[employeeId]`)
+- Individual employee breakdown page
+- Color-coded metrics and statistics
+- Smooth transitions between views
+- Detailed timesheet visualization
+
+### Manager Settings (`/client/manager/settings`)
+- Break rules management interface
+- Employee management with animations
+- Improved form interactions
+- Enhanced data tables
+
+## 🛠️ Technical Details
+
+### Dependencies
+- **framer-motion** (^12.23.25): Added for React animation library
+
+### Animation Patterns
+- Motion variants for consistent animation timing across components
+- AnimatePresence for smooth component lifecycle transitions
+- Transform-based animations for optimal performance
+- Staggered animations for list rendering
+
+### Styling
+- Tailwind CSS v4 with custom backdrop blur utilities
+- Consistent spacing and typography system
+- Responsive breakpoints optimized for mobile and desktop
+
+## 🎯 User Experience Improvements
+
+1. **Visual Feedback**: All interactive elements now provide clear visual feedback
+2. **Smooth Transitions**: Page navigation and state changes feel fluid and polished
+3. **Consistent Design**: Unified design language across all portal pages
+4. **Performance**: Optimized animations ensure smooth 60fps performance
+5. **Accessibility**: Maintained keyboard navigation and screen reader support
+
+## 🧪 Testing Recommendations
+
+- [ ] Test on mobile devices (iOS/Android)
+- [ ] Test on tablets (iPad in portrait/landscape)
+- [ ] Test on desktop browsers (Chrome, Firefox, Safari, Edge)
+- [ ] Verify animations perform smoothly on lower-end devices
+- [ ] Test keyboard navigation and accessibility features
+- [ ] Verify responsive breakpoints work correctly
+
+## 📸 Visual Changes
+
+The redesign introduces:
+- Modern glassmorphism effects with backdrop blur
+- Smooth entrance and exit animations
+- Enhanced hover states and interactive feedback
+- Improved visual hierarchy and spacing
+- Consistent color scheme throughout
+
+---
+
+**Note**: This PR focuses on UI/UX improvements and visual enhancements. All existing functionality remains intact with improved presentation and user experience.
+
+
+


### PR DESCRIPTION
# Summary
Fixed bug where break time wasn't recalculated when manager edits shift times via the EditTimesheetDialog
When shift times change, break_minutes is now reset to null so the database trigger recalculates it based on new duration

## Root Cause
The database trigger at [20251117_fix_break_calculation.sql:27-30](vscode-webview://0cjca0dib5ckd2hu8akkt0i5391j8rl4688b151nrboh75gbnupn/supabase/migrations/20251117_fix_break_calculation.sql#L27-L30) only calculates break_minutes when it's NULL:


IF NEW.break_minutes IS NULL THEN
  NEW.break_minutes := v_break_minutes;
END IF;
When updating an existing timesheet, the old break_minutes value (30 min) was preserved, so the trigger skipped recalculating it.

# Test plan

1. Setup: Ensure break rules are configured (e.g., 5+ hours = 30min break, under 5 hours = 0 break)
2. Create or find an employee with a 9-hour shift (e.g., 9:00 AM - 6:00 PM)
3. Verify the shift shows 30 minutes break time
4. Go to Manager Dashboard → click on employee → click Edit on that shift
5. Change the shift to under 5 hours (e.g., 9:30 AM - 10:50 AM)
6. Save the changes
7. Expected: Break time should now show 0 minutes (not 30 minutes)
8. Before fix: Break time incorrectly stayed at 30 minutes
