### PR TITLE
Feat/fruit clockin print documents

### DIFF
--- a/src/app/api/client/auth/employee/me/route.ts
+++ b/src/app/api/client/auth/employee/me/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
     // Fetch employee by id constrained to client
     const { data: employee, error: employeeError } = await supabase
       .from("employees")
-      .select("*")
+      .select("*, employee_categories(name)")
       .eq("id", sessionCookie)
       .eq("client_id", client.id)
       .single();
@@ -56,11 +56,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const categoryRow = employee.employee_categories as { name: string } | null;
     return NextResponse.json({
       employee: {
         id: employee.id,
         firstName: employee.first_name,
         lastName: employee.last_name,
+        categoryName: categoryRow?.name ?? null,
       },
     });
   } catch (error) {

--- a/src/app/api/client/auth/employee/me/route.ts
+++ b/src/app/api/client/auth/employee/me/route.ts
@@ -56,13 +56,17 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const categoryRow = employee.employee_categories as { name: string } | null;
+    const raw = employee.employee_categories as { name: string } | { name: string }[] | null;
+    const categoryName = Array.isArray(raw)
+      ? (raw[0]?.name ?? null)
+      : (raw?.name ?? null);
+
     return NextResponse.json({
       employee: {
         id: employee.id,
         firstName: employee.first_name,
         lastName: employee.last_name,
-        categoryName: categoryRow?.name ?? null,
+        categoryName,
       },
     });
   } catch (error) {

--- a/src/app/api/client/auth/employee/me/route.ts
+++ b/src/app/api/client/auth/employee/me/route.ts
@@ -56,7 +56,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const raw = employee.employee_categories as { name: string } | { name: string }[] | null;
+    const raw = employee.employee_categories as
+      | { name: string }
+      | { name: string }[]
+      | null;
     const categoryName = Array.isArray(raw)
       ? (raw[0]?.name ?? null)
       : (raw?.name ?? null);

--- a/src/app/client/employee/clock/page.tsx
+++ b/src/app/client/employee/clock/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { format } from "date-fns";
+import { motion } from "framer-motion";
+import { LogOut, Clock, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ClockState {
+  startTime: string | null; // HH:MM from saved timesheet
+  endTime: string | null;
+}
+
+export default function FruitClockPage() {
+  const router = useRouter();
+  const [employeeName, setEmployeeName] = useState("Employee");
+  const [employeeId, setEmployeeId] = useState("");
+  const [clockState, setClockState] = useState<ClockState>({ startTime: null, endTime: null });
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  // Live clock tick
+  useEffect(() => {
+    const interval = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Load employee + today's timesheet
+  const loadData = useCallback(async () => {
+    const meRes = await fetch("/api/client/auth/employee/me");
+    const meJson = await meRes.json() as {
+      employee?: { id: string; firstName?: string; lastName?: string };
+    };
+    if (!meRes.ok || !meJson.employee) {
+      router.push("/client/employee/login");
+      return;
+    }
+    const emp = meJson.employee;
+    setEmployeeName(`${emp.firstName ?? ""} ${emp.lastName ?? ""}`.trim() || "Employee");
+    setEmployeeId(emp.id);
+
+    const today = format(new Date(), "yyyy-MM-dd");
+    const tsRes = await fetch(`/api/client/timesheets?employeeId=${emp.id}&startDate=${today}&endDate=${today}`);
+    const tsJson = await tsRes.json() as { timesheets?: { start_time: string; end_time: string }[] };
+    const ts = tsJson.timesheets?.[0];
+    if (ts) {
+      setClockState({
+        startTime: ts.start_time?.slice(0, 5) ?? null,
+        endTime: ts.end_time?.slice(0, 5) ?? null,
+      });
+    }
+  }, [router]);
+
+  useEffect(() => { void loadData(); }, [loadData]);
+
+  const handleClockIn = async () => {
+    setLoading(true);
+    setError("");
+    const now = format(new Date(), "HH:mm");
+    const today = format(new Date(), "yyyy-MM-dd");
+    const res = await fetch("/api/client/timesheets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ employeeId, workDate: today, startTime: `${now}:00`, endTime: null }),
+    });
+    if (!res.ok) {
+      const json = await res.json() as { error?: string };
+      setError(json.error ?? "Failed to clock in");
+    } else {
+      setClockState({ startTime: now, endTime: null });
+    }
+    setLoading(false);
+  };
+
+  const handleClockOut = async () => {
+    setLoading(true);
+    setError("");
+    const now = format(new Date(), "HH:mm");
+    const today = format(new Date(), "yyyy-MM-dd");
+    const res = await fetch("/api/client/timesheets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ employeeId, workDate: today, startTime: `${clockState.startTime}:00`, endTime: `${now}:00` }),
+    });
+    if (!res.ok) {
+      const json = await res.json() as { error?: string };
+      setError(json.error ?? "Failed to clock out");
+    } else {
+      setClockState((prev) => ({ ...prev, endTime: now }));
+    }
+    setLoading(false);
+  };
+
+  const handleLogout = async () => {
+    await fetch("/api/client/auth/employee", { method: "DELETE" });
+    router.push("/client");
+  };
+
+  const isComplete = clockState.startTime !== null && clockState.endTime !== null;
+  const isClockedIn = clockState.startTime !== null && clockState.endTime === null;
+  const isNotClockedIn = clockState.startTime === null;
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-neutral-950 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-0 top-20 h-64 w-64 animate-pulse rounded-full bg-blue-500/5 blur-3xl" />
+        <div className="absolute bottom-20 right-0 h-64 w-64 animate-pulse rounded-full bg-blue-400/5 blur-3xl" />
+      </div>
+
+      {/* Header */}
+      <div className="absolute left-0 right-0 top-0 flex items-center justify-between border-b border-neutral-800 bg-neutral-900/80 px-6 py-4 backdrop-blur-lg">
+        <div>
+          <h1 className="text-xl font-bold">Welcome, <span className="text-primary">{employeeName}</span></h1>
+        </div>
+        <button
+          onClick={handleLogout}
+          className="flex items-center gap-2 rounded-xl border border-neutral-700 bg-neutral-800/50 px-3 py-2 text-sm transition-all hover:border-primary/50"
+        >
+          <LogOut className="h-4 w-4" />
+          <span>Logout</span>
+        </button>
+      </div>
+
+      {/* Main */}
+      <div className="relative flex w-full max-w-sm flex-col items-center gap-8 px-6">
+        {/* Live clock */}
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center"
+        >
+          <p className="text-6xl font-bold tabular-nums">{format(currentTime, "HH:mm")}</p>
+          <p className="mt-2 text-neutral-400">{format(currentTime, "EEEE, d MMMM yyyy")}</p>
+        </motion.div>
+
+        {error && (
+          <div className="w-full rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-center text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* State: not clocked in */}
+        {isNotClockedIn && (
+          <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="w-full">
+            <Button
+              onClick={handleClockIn}
+              disabled={loading || !employeeId}
+              className="h-24 w-full rounded-2xl bg-gradient-to-r from-green-500 to-emerald-600 text-2xl font-bold shadow-lg shadow-green-500/30 hover:shadow-xl hover:shadow-green-500/40 disabled:opacity-50"
+            >
+              {loading ? <Clock className="animate-spin h-8 w-8" /> : "Clock In"}
+            </Button>
+          </motion.div>
+        )}
+
+        {/* State: clocked in, no clock out yet */}
+        {isClockedIn && (
+          <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="w-full space-y-4">
+            <div className="rounded-xl border border-green-500/30 bg-green-500/10 p-4 text-center">
+              <p className="text-sm text-neutral-400">Clocked in at</p>
+              <p className="text-3xl font-bold text-green-400">{clockState.startTime}</p>
+            </div>
+            <Button
+              onClick={handleClockOut}
+              disabled={loading}
+              className="h-24 w-full rounded-2xl bg-gradient-to-r from-red-500 to-rose-600 text-2xl font-bold shadow-lg shadow-red-500/30 hover:shadow-xl hover:shadow-red-500/40 disabled:opacity-50"
+            >
+              {loading ? <Clock className="animate-spin h-8 w-8" /> : "Clock Out"}
+            </Button>
+          </motion.div>
+        )}
+
+        {/* State: complete for today */}
+        {isComplete && (
+          <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="w-full">
+            <div className="rounded-xl border border-blue-500/30 bg-blue-500/10 p-6 text-center space-y-3">
+              <CheckCircle2 className="mx-auto h-10 w-10 text-primary" />
+              <p className="text-lg font-semibold">Done for today!</p>
+              <div className="flex justify-center gap-8 text-sm text-neutral-400">
+                <div>
+                  <p>In</p>
+                  <p className="text-xl font-bold text-white">{clockState.startTime}</p>
+                </div>
+                <div>
+                  <p>Out</p>
+                  <p className="text-xl font-bold text-white">{clockState.endTime}</p>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/client/employee/clock/page.tsx
+++ b/src/app/client/employee/clock/page.tsx
@@ -112,6 +112,14 @@ export default function FruitClockPage() {
   const isClockedIn = clockState.startTime !== null && clockState.endTime === null;
   const isNotClockedIn = clockState.startTime === null;
 
+  const formatAmPm = (time: string | null) => {
+    if (!time) return "";
+    const [h, m] = time.split(":").map(Number);
+    const period = h! >= 12 ? "PM" : "AM";
+    const hour = h! % 12 || 12;
+    return `${hour}:${String(m).padStart(2, "0")} ${period}`;
+  };
+
   return (
     <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-neutral-950 text-white">
       <div className="pointer-events-none absolute inset-0">
@@ -141,7 +149,7 @@ export default function FruitClockPage() {
           animate={{ opacity: 1, y: 0 }}
           className="text-center"
         >
-          <p className="text-6xl font-bold tabular-nums">{format(currentTime, "HH:mm")}</p>
+          <p className="text-6xl font-bold tabular-nums">{format(currentTime, "h:mm a")}</p>
           <p className="mt-2 text-neutral-400">{format(currentTime, "EEEE, d MMMM yyyy")}</p>
         </motion.div>
 
@@ -169,7 +177,7 @@ export default function FruitClockPage() {
           <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="w-full space-y-4">
             <div className="rounded-xl border border-green-500/30 bg-green-500/10 p-4 text-center">
               <p className="text-sm text-neutral-400">Clocked in at</p>
-              <p className="text-3xl font-bold text-green-400">{clockState.startTime}</p>
+              <p className="text-3xl font-bold text-green-400">{formatAmPm(clockState.startTime)}</p>
             </div>
             <Button
               onClick={handleClockOut}
@@ -190,11 +198,11 @@ export default function FruitClockPage() {
               <div className="flex justify-center gap-8 text-sm text-neutral-400">
                 <div>
                   <p>In</p>
-                  <p className="text-xl font-bold text-white">{clockState.startTime}</p>
+                  <p className="text-xl font-bold text-white">{formatAmPm(clockState.startTime)}</p>
                 </div>
                 <div>
                   <p>Out</p>
-                  <p className="text-xl font-bold text-white">{clockState.endTime}</p>
+                  <p className="text-xl font-bold text-white">{formatAmPm(clockState.endTime)}</p>
                 </div>
               </div>
             </div>

--- a/src/app/client/employee/clock/page.tsx
+++ b/src/app/client/employee/clock/page.tsx
@@ -43,6 +43,10 @@ export default function FruitClockPage() {
 
     const today = format(new Date(), "yyyy-MM-dd");
     const tsRes = await fetch(`/api/client/timesheets?employeeId=${emp.id}&startDate=${today}&endDate=${today}`);
+    if (!tsRes.ok) {
+      // silently accept "not clocked in" state on fetch failure
+      return;
+    }
     const tsJson = await tsRes.json() as { timesheets?: { start_time: string; end_time: string }[] };
     const ts = tsJson.timesheets?.[0];
     if (ts) {
@@ -56,6 +60,7 @@ export default function FruitClockPage() {
   useEffect(() => { void loadData(); }, [loadData]);
 
   const handleClockIn = async () => {
+    if (loading) return;
     setLoading(true);
     setError("");
     const now = format(new Date(), "HH:mm");
@@ -75,6 +80,11 @@ export default function FruitClockPage() {
   };
 
   const handleClockOut = async () => {
+    if (loading) return;
+    if (!clockState.startTime) {
+      setError("Clock in time not found. Please try again.");
+      return;
+    }
     setLoading(true);
     setError("");
     const now = format(new Date(), "HH:mm");

--- a/src/app/client/employee/login/page.tsx
+++ b/src/app/client/employee/login/page.tsx
@@ -44,8 +44,24 @@ export default function EmployeeLoginPage() {
         return;
       }
 
-      // Redirect to employee dashboard on success
-      router.push("/client/employee/dashboard");
+      // Fetch employee details to check category
+      const meRes = await fetch("/api/client/auth/employee/me");
+      const meJson = (await meRes.json()) as {
+        employee?: {
+          id: string;
+          firstName?: string;
+          lastName?: string;
+          categoryName?: string | null;
+        };
+      };
+      const categoryName = meJson.employee?.categoryName ?? null;
+
+      // Redirect based on category
+      if (categoryName === "Fruit") {
+        router.push("/client/employee/clock");
+      } else {
+        router.push("/client/employee/dashboard");
+      }
     } catch (err) {
       setError("An error occurred");
     } finally {

--- a/src/app/client/employee/login/page.tsx
+++ b/src/app/client/employee/login/page.tsx
@@ -46,6 +46,10 @@ export default function EmployeeLoginPage() {
 
       // Fetch employee details to check category
       const meRes = await fetch("/api/client/auth/employee/me");
+      if (!meRes.ok) {
+        setError("Failed to load employee info. Please try again.");
+        return;
+      }
       const meJson = (await meRes.json()) as {
         employee?: {
           id: string;
@@ -54,7 +58,11 @@ export default function EmployeeLoginPage() {
           categoryName?: string | null;
         };
       };
-      const categoryName = meJson.employee?.categoryName ?? null;
+      if (!meJson.employee) {
+        setError("Failed to load employee info. Please try again.");
+        return;
+      }
+      const categoryName = meJson.employee.categoryName ?? null;
 
       // Redirect based on category
       if (categoryName === "Fruit") {

--- a/src/app/client/manager/dashboard/page.tsx
+++ b/src/app/client/manager/dashboard/page.tsx
@@ -38,7 +38,8 @@ import {
 import { startOfWeek, endOfWeek, addWeeks, format, getDay } from "date-fns";
 import type { Employee, EmployeeCategory, TimesheetWithEmployee } from "@/types/database";
 import { formatHoursAndMinutes } from "@/lib/timeUtils";
-import { exportPayrollToCSV, printPayrollCSV } from "@/lib/csvExport";
+import { exportPayrollToCSV } from "@/lib/csvExport";
+import { PrintSelectModal } from "@/components/PrintSelectModal";
 import { motion, AnimatePresence } from "framer-motion";
 import { DatePicker } from "@/components/ui/date-picker";
 import { isPublicHoliday } from "@/lib/holidays";
@@ -73,6 +74,7 @@ function ManagerDashboardContent() {
   const [searchQuery, setSearchQuery] = useState("");
   const [categories, setCategories] = useState<EmployeeCategory[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [printModalOpen, setPrintModalOpen] = useState(false);
 
   // Date range picker state - initialize from URL if available
   const [viewMode, setViewMode] = useState<"week" | "custom">(
@@ -360,28 +362,6 @@ function ManagerDashboardContent() {
     });
   };
 
-  /**
-   * Handle print payroll
-   */
-  const handlePrintCSV = () => {
-    const employeeData = filteredEmployees.map((emp) => ({
-      firstName: emp.first_name,
-      lastName: emp.last_name,
-      weekdayHours: emp.weekdayHours,
-      saturdayHours: emp.saturdayHours,
-      sundayHours: emp.sundayHours,
-      totalHours: emp.totalHours,
-      payType: emp.pay_type,
-      breakMinutes: emp.breakMinutes,
-      applyBreakRules: emp.apply_break_rules,
-    }));
-
-    printPayrollCSV({
-      employees: employeeData,
-      weekEndingDate: actualEndDate, // Use end date as week-ending date
-    });
-  };
-
   // Memoized: Calculate summary stats
   const { totalPay, totalHours } = useMemo(() => ({
     totalPay: employees.reduce((sum, emp) => sum + emp.totalPay, 0),
@@ -608,7 +588,7 @@ function ManagerDashboardContent() {
             </div>
             <div className="flex gap-2">
               <Button
-                onClick={handlePrintCSV}
+                onClick={() => setPrintModalOpen(true)}
                 variant="outline"
                 className="border-neutral-700 bg-neutral-800/50 backdrop-blur-sm transition-all hover:border-primary/50 hover:bg-neutral-800"
                 disabled={filteredEmployees.length === 0}
@@ -819,6 +799,14 @@ function ManagerDashboardContent() {
           )}
         </div>
       </main>
+      <PrintSelectModal
+        open={printModalOpen}
+        onClose={() => setPrintModalOpen(false)}
+        employees={rawEmployees}
+        timesheets={rawTimesheets}
+        weekStart={actualStartDate}
+        weekEnd={actualEndDate}
+      />
     </div>
   );
 }

--- a/src/components/PrintSelectModal.tsx
+++ b/src/components/PrintSelectModal.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { printWeekSummary, printDayBreakdown } from "@/lib/csvExport";
+import type { Employee, TimesheetWithEmployee } from "@/types/database";
+import { format, getDay } from "date-fns";
+import { isPublicHoliday } from "@/lib/holidays";
+
+interface PrintSelectModalProps {
+  open: boolean;
+  onClose: () => void;
+  employees: Employee[];
+  timesheets: TimesheetWithEmployee[];
+  weekStart: Date;
+  weekEnd: Date;
+}
+
+type DayType = "weekday" | "saturday" | "sunday" | "public_holiday";
+
+function getDayType(dateString: string): DayType {
+  if (isPublicHoliday(dateString)) return "public_holiday";
+  const d = getDay(new Date(dateString));
+  if (d === 0) return "sunday";
+  if (d === 6) return "saturday";
+  return "weekday";
+}
+
+export function PrintSelectModal({
+  open,
+  onClose,
+  employees,
+  timesheets,
+  weekStart,
+  weekEnd,
+}: PrintSelectModalProps) {
+  const [selected, setSelected] = useState<"week-summary" | "day-breakdown" | null>(null);
+
+  const handlePrint = () => {
+    if (!selected) return;
+
+    if (selected === "week-summary") {
+      const empData = employees.map((emp) => {
+        const empTs = timesheets.filter((ts) => ts.employee_id === emp.id);
+        let weekdayHours = 0, saturdayHours = 0, sundayHours = 0;
+        for (const ts of empTs) {
+          const type = getDayType(ts.work_date);
+          const h = parseFloat(ts.total_hours.toString());
+          if (type === "saturday") saturdayHours += h;
+          else if (type === "sunday") sundayHours += h;
+          else weekdayHours += h;
+        }
+        return {
+          firstName: emp.first_name,
+          lastName: emp.last_name,
+          weekdayHours,
+          saturdayHours,
+          sundayHours,
+          totalHours: weekdayHours + saturdayHours + sundayHours,
+        };
+      }).filter((e) => e.totalHours > 0);
+
+      printWeekSummary({ employees: empData, weekEndingDate: weekEnd });
+    } else {
+      const empData = employees.map((emp) => {
+        const empTs = timesheets.filter((ts) => ts.employee_id === emp.id);
+        const dailyHours: Record<string, number> = {};
+        for (const ts of empTs) {
+          const iso = format(new Date(ts.work_date), "yyyy-MM-dd");
+          dailyHours[iso] = (dailyHours[iso] ?? 0) + parseFloat(ts.total_hours.toString());
+        }
+        return { firstName: emp.first_name, lastName: emp.last_name, dailyHours };
+      }).filter((e) => Object.keys(e.dailyHours).length > 0);
+
+      printDayBreakdown({ employees: empData, weekStart, weekEnd });
+    }
+
+    onClose();
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+          />
+
+          {/* Modal */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 10 }}
+            className="relative z-10 w-full max-w-sm rounded-2xl border border-neutral-700 bg-neutral-900 p-6 shadow-2xl"
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Select Print Format</h2>
+              <button onClick={onClose} className="rounded-lg p-1 text-neutral-400 hover:text-white">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {(["week-summary", "day-breakdown"] as const).map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => setSelected(opt)}
+                  className={`flex w-full items-center gap-3 rounded-xl border p-4 text-left transition-all ${
+                    selected === opt
+                      ? "border-primary bg-primary/10 text-white"
+                      : "border-neutral-700 hover:border-neutral-500"
+                  }`}
+                >
+                  <FileText className="h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <p className="font-medium">
+                      {opt === "week-summary" ? "Week Summary" : "Day Breakdown"}
+                    </p>
+                    <p className="text-xs text-neutral-400">
+                      {opt === "week-summary"
+                        ? "One row per employee — weekly hour totals"
+                        : "One row per employee — hours per day across the week"}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            <Button
+              onClick={handlePrint}
+              disabled={!selected}
+              className="mt-6 w-full bg-gradient-to-r from-primary to-blue-500 disabled:opacity-40"
+            >
+              Print
+            </Button>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/PrintSelectModal.tsx
+++ b/src/components/PrintSelectModal.tsx
@@ -50,7 +50,7 @@ export function PrintSelectModal({
           const h = parseFloat(ts.total_hours.toString());
           if (type === "saturday") saturdayHours += h;
           else if (type === "sunday") sundayHours += h;
-          else weekdayHours += h;
+          else weekdayHours += h; // public holidays count as ordinary hours (no separate column)
         }
         return {
           firstName: emp.first_name,
@@ -102,7 +102,7 @@ export function PrintSelectModal({
           >
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold">Select Print Format</h2>
-              <button onClick={onClose} className="rounded-lg p-1 text-neutral-400 hover:text-white">
+              <button onClick={onClose} aria-label="Close modal" className="rounded-lg p-1 text-neutral-400 hover:text-white">
                 <X className="h-5 w-5" />
               </button>
             </div>

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -281,3 +281,206 @@ export function printPayrollCSV({
     win.close();
   }, 300);
 }
+
+// ─── Week Summary ────────────────────────────────────────────────────────────
+
+interface WeekSummaryEmployee {
+  firstName: string;
+  lastName: string;
+  weekdayHours: number;
+  saturdayHours: number;
+  sundayHours: number;
+  totalHours: number;
+  notes?: string;
+}
+
+interface WeekSummaryOptions {
+  employees: WeekSummaryEmployee[];
+  weekEndingDate: Date;
+}
+
+export function printWeekSummary({ employees, weekEndingDate }: WeekSummaryOptions): void {
+  const formattedDate = formatDateAU(weekEndingDate);
+  const win = window.open("", "_blank", "width=900,height=700");
+  if (!win) { alert("Pop-ups are blocked. Please allow pop-ups for this site to use the print function."); return; }
+
+  const doc = win.document;
+  doc.title = `Week Summary - ${formattedDate}`;
+
+  const style = doc.createElement("style");
+  style.textContent = `
+    @media print { @page { margin: 1cm; size: auto; } body { margin: 0; } }
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    h1 { font-size: 18px; margin-bottom: 10px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+    th, td { border: 1px solid #333; padding: 8px; text-align: left; }
+    th { background-color: #f0f0f0; font-weight: bold; }
+    tr:nth-child(even) { background-color: #f9f9f9; }
+    .numeric { text-align: right; }
+  `;
+  doc.head.appendChild(style);
+
+  const h1 = doc.createElement("h1");
+  h1.textContent = `Week Summary - Week Ending ${formattedDate}`;
+  doc.body.appendChild(h1);
+
+  const table = doc.createElement("table");
+  const thead = doc.createElement("thead");
+  const headerRow = doc.createElement("tr");
+  const headers: { label: string; numeric: boolean }[] = [
+    { label: "First Name", numeric: false },
+    { label: "Last Name", numeric: false },
+    { label: "Date", numeric: false },
+    { label: "Ordinary Hours", numeric: true },
+    { label: "Saturday Hours", numeric: true },
+    { label: "Sunday Hours", numeric: true },
+    { label: "Total Hours", numeric: true },
+    { label: "Notes", numeric: false },
+  ];
+  for (const h of headers) {
+    const th = doc.createElement("th");
+    if (h.numeric) th.className = "numeric";
+    th.textContent = h.label;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = doc.createElement("tbody");
+  for (const emp of employees) {
+    const tr = doc.createElement("tr");
+    const cells: { value: string; numeric: boolean }[] = [
+      { value: emp.firstName, numeric: false },
+      { value: emp.lastName, numeric: false },
+      { value: formattedDate, numeric: false },
+      { value: emp.weekdayHours.toFixed(2), numeric: true },
+      { value: emp.saturdayHours.toFixed(2), numeric: true },
+      { value: emp.sundayHours.toFixed(2), numeric: true },
+      { value: emp.totalHours.toFixed(2), numeric: true },
+      { value: emp.notes ?? "", numeric: false },
+    ];
+    for (const cell of cells) {
+      const td = doc.createElement("td");
+      if (cell.numeric) td.className = "numeric";
+      td.textContent = cell.value;
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  doc.body.appendChild(table);
+
+  setTimeout(() => { win.focus(); win.print(); win.close(); }, 300);
+}
+
+// ─── Day Breakdown ───────────────────────────────────────────────────────────
+
+interface DayBreakdownEmployee {
+  firstName: string;
+  lastName: string;
+  // hours per ISO date string (yyyy-MM-dd), only days with entries present
+  dailyHours: Record<string, number>;
+  notes?: string;
+}
+
+interface DayBreakdownOptions {
+  employees: DayBreakdownEmployee[];
+  weekStart: Date; // Monday of the week
+  weekEnd: Date;   // Sunday of the week
+}
+
+export function printDayBreakdown({ employees, weekStart, weekEnd }: DayBreakdownOptions): void {
+  const startLabel = formatDateAU(weekStart);
+  const endLabel = formatDateAU(weekEnd);
+
+  const win = window.open("", "_blank", "width=1100,height=700");
+  if (!win) { alert("Pop-ups are blocked. Please allow pop-ups for this site to use the print function."); return; }
+
+  const doc = win.document;
+  doc.title = `Day Breakdown - ${startLabel} to ${endLabel}`;
+
+  const style = doc.createElement("style");
+  style.textContent = `
+    @media print { @page { margin: 1cm; size: landscape; } body { margin: 0; } }
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    h1 { font-size: 18px; margin-bottom: 10px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+    th, td { border: 1px solid #333; padding: 6px 8px; text-align: left; }
+    th { background-color: #f0f0f0; font-weight: bold; }
+    tr:nth-child(even) { background-color: #f9f9f9; }
+    .numeric { text-align: right; }
+  `;
+  doc.head.appendChild(style);
+
+  const h1 = doc.createElement("h1");
+  h1.textContent = `Day Breakdown - ${startLabel} to ${endLabel}`;
+  doc.body.appendChild(h1);
+
+  // Build ordered list of 7 days Mon→Sun
+  const days: { iso: string; label: string }[] = [];
+  const cursor = new Date(weekStart);
+  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  for (let i = 0; i < 7; i++) {
+    const dd = String(cursor.getDate()).padStart(2, "0");
+    const mm = String(cursor.getMonth() + 1).padStart(2, "0");
+    days.push({
+      iso: `${cursor.getFullYear()}-${mm}-${dd}`,
+      label: `${dayLabels[i]} ${dd}/${mm}`,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  const table = doc.createElement("table");
+  const thead = doc.createElement("thead");
+  const headerRow = doc.createElement("tr");
+
+  const fixedHeaders: { label: string; numeric: boolean }[] = [
+    { label: "First Name", numeric: false },
+    { label: "Last Name", numeric: false },
+    { label: "Date Range", numeric: false },
+  ];
+  for (const h of fixedHeaders) {
+    const th = doc.createElement("th");
+    th.textContent = h.label;
+    headerRow.appendChild(th);
+  }
+  for (const day of days) {
+    const th = doc.createElement("th");
+    th.className = "numeric";
+    th.textContent = day.label;
+    headerRow.appendChild(th);
+  }
+  const notesTh = doc.createElement("th");
+  notesTh.textContent = "Notes";
+  headerRow.appendChild(notesTh);
+
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = doc.createElement("tbody");
+  for (const emp of employees) {
+    const tr = doc.createElement("tr");
+
+    const addCell = (text: string, numeric = false) => {
+      const td = doc.createElement("td");
+      if (numeric) td.className = "numeric";
+      td.textContent = text;
+      tr.appendChild(td);
+    };
+
+    addCell(emp.firstName);
+    addCell(emp.lastName);
+    addCell(`${startLabel} - ${endLabel}`);
+    for (const day of days) {
+      const hours = emp.dailyHours[day.iso];
+      addCell(hours != null && hours > 0 ? hours.toFixed(2) : "", true);
+    }
+    addCell(emp.notes ?? "");
+
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  doc.body.appendChild(table);
+
+  setTimeout(() => { win.focus(); win.print(); win.close(); }, 300);
+}

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -401,14 +401,15 @@ export function printDayBreakdown({ employees, weekStart, weekEnd }: DayBreakdow
 
   const style = doc.createElement("style");
   style.textContent = `
-    @media print { @page { margin: 1cm; size: landscape; } body { margin: 0; } }
+    @media print { @page { margin: 1cm; size: portrait; } body { margin: 0; } }
     body { font-family: Arial, sans-serif; padding: 20px; }
     h1 { font-size: 18px; margin-bottom: 10px; }
     table { width: 100%; border-collapse: collapse; margin-top: 20px; }
     th, td { border: 1px solid #333; padding: 6px 8px; text-align: left; }
     th { background-color: #f0f0f0; font-weight: bold; }
     tr:nth-child(even) { background-color: #f9f9f9; }
-    .numeric { text-align: right; }
+    .numeric { text-align: center; }
+    .empty { text-align: center; color: #999; }
   `;
   doc.head.appendChild(style);
 
@@ -473,7 +474,14 @@ export function printDayBreakdown({ employees, weekStart, weekEnd }: DayBreakdow
     addCell(`${startLabel} - ${endLabel}`);
     for (const day of days) {
       const hours = emp.dailyHours[day.iso];
-      addCell(hours != null && hours > 0 ? hours.toFixed(2) : "", true);
+      if (hours != null && hours > 0) {
+        addCell(hours.toFixed(2), true);
+      } else {
+        const td = doc.createElement("td");
+        td.className = "empty";
+        td.textContent = "-";
+        tr.appendChild(td);
+      }
     }
     addCell(emp.notes ?? "");
 


### PR DESCRIPTION
## Summary

- **Fruit employee clock-in screen** — employees in the Fruit category are redirected to a dedicated `/client/employee/clock` page after login, where they can clock in and out with a single tap. Times are displayed in AM/PM format.
- **Print format selector** — the Print button on the manager dashboard now opens a modal letting managers choose between two report formats: Week Summary (one row per employee, hours split by ordinary/Saturday/Sunday) and Day Breakdown (one row per employee, hours per weekday across the selected week).
- **Day Breakdown improvements** — empty day cells show a dash, columns are centre-aligned, and the report prints in portrait orientation.

## Changes

### New files
- `src/app/client/employee/clock/page.tsx` — Fruit-only clock in/out screen
- `src/components/PrintSelectModal.tsx` — modal to choose print format

### Modified files
- `src/app/api/client/auth/employee/me/route.ts` — returns `categoryName` in response (joins `employee_categories`)
- `src/app/client/employee/login/page.tsx` — redirects Fruit employees to `/clock` after login
- `src/lib/csvExport.ts` — adds `printWeekSummary` and `printDayBreakdown` functions
- `src/app/client/manager/dashboard/page.tsx` — wires Print button to `PrintSelectModal`

## Test Plan

- [ ] Log in as a **Fruit** category employee → lands on `/client/employee/clock`
- [ ] Log in as a **non-Fruit** employee → lands on `/client/employee/dashboard` (no regression)
- [ ] Clock In records start time; Clock Out records end time; summary card shows both in AM/PM
- [ ] Times persist on page refresh
- [ ] Hours appear on manager dashboard after clock-in
- [ ] Manager dashboard Print button opens the format selector modal
- [ ] Week Summary prints a table with ordinary/Saturday/Sunday hour columns
- [ ] Day Breakdown prints portrait, with `-` for empty days and centred day columns
- [ ] CSV Export button still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
