### PR TITLE
fix: correct days worked count for fruit clock-in employees

### DIFF
--- a/src/app/client/manager/employee/[employeeId]/page.tsx
+++ b/src/app/client/manager/employee/[employeeId]/page.tsx
@@ -166,7 +166,7 @@ function EmployeeDetailContent() {
     (sum, day) => sum + day.breakMinutes,
     0,
   );
-  const daysWorked = dailyBreakdown.filter((day) => day.totalHours > 0).length;
+  const daysWorked = dailyBreakdown.filter((day) => day.endTime !== null).length;
 
   // Function to navigate back with URL params
   const handleBackToDashboard = () => {

--- a/src/lib/payrollRates.ts
+++ b/src/lib/payrollRates.ts
@@ -26,9 +26,10 @@ export function payrollForPeriod(
   emp: Employee,
   sheets: TimesheetWithEmployee[],
 ): { totalPay: number; daysWorked: number } {
-  if (sheets.length === 0) return { totalPay: 0, daysWorked: 0 };
+  const complete = sheets.filter((r) => !!r.end_time);
+  if (complete.length === 0) return { totalPay: 0, daysWorked: 0 };
 
-  const uniqueDates = new Set(sheets.map((r) => r.work_date));
+  const uniqueDates = new Set(complete.map((r) => r.work_date));
   const daysWorked = uniqueDates.size;
 
   if (emp.pay_type === "day_rate") {
@@ -40,7 +41,7 @@ export function payrollForPeriod(
   }
 
   let totalPay = 0;
-  for (const ts of sheets) {
+  for (const ts of complete) {
     const h = parseFloat(ts.total_hours.toString());
     totalPay += h * rateForDate(ts.work_date, emp);
   }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -74,7 +74,7 @@ export interface Timesheet {
   client_id: string;
   work_date: string; // ISO date string
   start_time: string; // HH:MM:SS
-  end_time: string; // HH:MM:SS
+  end_time: string | null; // HH:MM:SS, null if employee has not yet clocked out
   break_minutes: number;
   total_hours: number;
   notes?: string;


### PR DESCRIPTION
Two separate bugs caused days worked to disagree between the dashboard card and the employee detail view:

1. payrollForPeriod counted timesheets with end_time = null (employee clocked in but never out), inflating daysWorked and totalPay for day-rate employees on the dashboard card.

2. The detail view filtered daysWorked by totalHours > 0, incorrectly excluding days where clock-in and clock-out were recorded at the same minute (totalHours = 0 but the day is complete and billable).

Fix: filter to complete timesheets only in payrollForPeriod, and use endTime !== null instead of totalHours > 0 in the detail view week summary.

Also tightens Timesheet.end_time type to string | null to reflect the actual database schema.