### PR TITLE
Feat/category dashboard views

### DIFF
--- a/src/app/api/client/auth/employee/me/route.ts
+++ b/src/app/api/client/auth/employee/me/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
     // Fetch employee by id constrained to client
     const { data: employee, error: employeeError } = await supabase
       .from("employees")
-      .select("*, employee_categories(name)")
+      .select("*, employee_categories(name, dashboard_view)")
       .eq("id", sessionCookie)
       .eq("client_id", client.id)
       .single();
@@ -57,12 +57,12 @@ export async function GET(request: NextRequest) {
     }
 
     const raw = employee.employee_categories as
-      | { name: string }
-      | { name: string }[]
+      | { name: string; dashboard_view: string }
+      | { name: string; dashboard_view: string }[]
       | null;
-    const categoryName = Array.isArray(raw)
-      ? (raw[0]?.name ?? null)
-      : (raw?.name ?? null);
+    const categoryEntry = Array.isArray(raw) ? (raw[0] ?? null) : raw;
+    const categoryName = categoryEntry?.name ?? null;
+    const dashboardView = (categoryEntry?.dashboard_view ?? 'weekly') as 'weekly' | 'today_only';
 
     return NextResponse.json({
       employee: {
@@ -70,6 +70,7 @@ export async function GET(request: NextRequest) {
         firstName: employee.first_name,
         lastName: employee.last_name,
         categoryName,
+        dashboardView,
       },
     });
   } catch (error) {

--- a/src/app/api/client/categories/[id]/route.ts
+++ b/src/app/api/client/categories/[id]/route.ts
@@ -35,18 +35,38 @@ export async function PUT(
     const { supabase, clientId } = ctx;
     const { id } = await params;
 
-    const { name } = (await request.json()) as { name?: string };
+    const body = (await request.json()) as { name?: string; dashboardView?: string };
+    const { name } = body;
 
-    if (!name || !name.trim()) {
-      return NextResponse.json(
-        { error: "Category name is required" },
-        { status: 400 },
-      );
+    const updatePayload: Record<string, string> = {};
+
+    if (name !== undefined) {
+      if (!name.trim()) {
+        return NextResponse.json(
+          { error: "Category name cannot be empty" },
+          { status: 400 },
+        );
+      }
+      updatePayload.name = name.trim();
+    }
+
+    if (body.dashboardView !== undefined) {
+      if (body.dashboardView !== 'weekly' && body.dashboardView !== 'today_only') {
+        return NextResponse.json(
+          { error: "Invalid dashboard_view value" },
+          { status: 400 },
+        );
+      }
+      updatePayload.dashboard_view = body.dashboardView;
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
     }
 
     const { data: category, error } = await supabase
       .from("employee_categories")
-      .update({ name: name.trim() })
+      .update(updatePayload)
       .eq("id", id)
       .eq("client_id", clientId)
       .select()

--- a/src/app/api/client/categories/route.ts
+++ b/src/app/api/client/categories/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: NextRequest) {
       id: cat.id,
       client_id: cat.client_id,
       name: cat.name,
+      dashboard_view: (cat.dashboard_view ?? 'weekly') as 'weekly' | 'today_only',
       created_at: cat.created_at,
       employee_count: Array.isArray(cat.employees) ? cat.employees.length : 0,
     }));
@@ -71,7 +72,9 @@ export async function POST(request: NextRequest) {
     }
     const { supabase, clientId } = ctx;
 
-    const { name } = (await request.json()) as { name?: string };
+    const body = (await request.json()) as { name?: string; dashboardView?: string };
+    const { name } = body;
+    const dashboardView = body.dashboardView === 'today_only' ? 'today_only' : 'weekly';
 
     if (!name || !name.trim()) {
       return NextResponse.json(
@@ -82,7 +85,7 @@ export async function POST(request: NextRequest) {
 
     const { data: category, error } = await supabase
       .from("employee_categories")
-      .insert({ client_id: clientId, name: name.trim() })
+      .insert({ client_id: clientId, name: name.trim(), dashboard_view: dashboardView })
       .select()
       .single();
 

--- a/src/app/client/employee/login/page.tsx
+++ b/src/app/client/employee/login/page.tsx
@@ -56,16 +56,17 @@ export default function EmployeeLoginPage() {
           firstName?: string;
           lastName?: string;
           categoryName?: string | null;
+          dashboardView?: 'weekly' | 'today_only' | null;
         };
       };
       if (!meJson.employee) {
         setError("Failed to load employee info. Please try again.");
         return;
       }
-      const categoryName = meJson.employee.categoryName ?? null;
+      const dashboardView = meJson.employee.dashboardView ?? 'weekly';
 
-      // Redirect based on category
-      if (categoryName === "Fruit") {
+      // Redirect based on configured dashboard view for this category
+      if (dashboardView === 'today_only') {
         router.push("/client/employee/clock");
       } else {
         router.push("/client/employee/dashboard");

--- a/src/app/client/manager/settings/page.tsx
+++ b/src/app/client/manager/settings/page.tsx
@@ -55,6 +55,13 @@ export default function ManagerSettingsPage() {
   const [bulkOpen, setBulkOpen] = useState(false);
   const BULK_PAGE_SIZE = 10;
 
+  // Preview panel state
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewView, setPreviewView] = useState<'weekly' | 'today_only'>('weekly');
+
+  // Per-category view update loading state
+  const [updatingViewId, setUpdatingViewId] = useState<string | null>(null);
+
   /**
    * Fetch employees
    */
@@ -261,6 +268,30 @@ export default function ManagerSettingsPage() {
       }
     } catch (error) {
       console.error("Error deleting category:", error);
+    }
+  };
+
+  /**
+   * Update dashboard view for a category (auto-saves on toggle)
+   */
+  const handleUpdateDashboardView = async (id: string, view: 'weekly' | 'today_only') => {
+    setUpdatingViewId(id);
+    try {
+      const response = await fetch(`/api/client/categories/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dashboardView: view }),
+      });
+      if (response.ok) {
+        await fetchCategories();
+      } else {
+        const data = (await response.json()) as { error?: string };
+        alert(data.error ?? "Failed to update view");
+      }
+    } catch (error) {
+      console.error("Error updating dashboard view:", error);
+    } finally {
+      setUpdatingViewId(null);
     }
   };
 
@@ -510,13 +541,46 @@ export default function ManagerSettingsPage() {
                     </div>
                   ) : (
                     <>
-                      <div className="flex items-center gap-2">
+                      {/* Name + employee count */}
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
                         <span className="font-medium">{cat.name}</span>
                         <span className="text-xs text-neutral-500">
                           {categoryEmployeeCounts[cat.id] ?? 0} employee{(categoryEmployeeCounts[cat.id] ?? 0) !== 1 ? "s" : ""}
                         </span>
                       </div>
-                      <div className="flex gap-2">
+
+                      {/* Inline segmented view toggle */}
+                      <div className="mx-3 flex shrink-0 items-center rounded-lg border border-neutral-700 bg-neutral-800 p-0.5">
+                        <button
+                          disabled={updatingViewId === cat.id}
+                          onClick={() => {
+                            if (cat.dashboard_view !== 'weekly') void handleUpdateDashboardView(cat.id, 'weekly');
+                          }}
+                          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                            cat.dashboard_view === 'weekly'
+                              ? "bg-neutral-600 text-neutral-100 shadow-sm"
+                              : "text-neutral-500 hover:text-neutral-300"
+                          }`}
+                        >
+                          Weekly Schedule
+                        </button>
+                        <button
+                          disabled={updatingViewId === cat.id}
+                          onClick={() => {
+                            if (cat.dashboard_view !== 'today_only') void handleUpdateDashboardView(cat.id, 'today_only');
+                          }}
+                          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                            cat.dashboard_view === 'today_only'
+                              ? "bg-neutral-600 text-neutral-100 shadow-sm"
+                              : "text-neutral-500 hover:text-neutral-300"
+                          }`}
+                        >
+                          Clock In/Out
+                        </button>
+                      </div>
+
+                      {/* Rename + Delete actions */}
+                      <div className="flex shrink-0 gap-2">
                         <button
                           onClick={() => { setRenamingId(cat.id); setRenameValue(cat.name); }}
                           className="flex items-center gap-1 rounded-lg border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-400 hover:border-neutral-600 hover:text-neutral-200"

--- a/src/app/client/manager/settings/page.tsx
+++ b/src/app/client/manager/settings/page.tsx
@@ -770,6 +770,104 @@ export default function ManagerSettingsPage() {
                 )}
               </div>
             )}
+
+            {/* View Preview Panel */}
+            <div className="mt-6 border-t border-neutral-800 pt-5">
+              <button
+                onClick={() => setPreviewOpen((o) => !o)}
+                className="flex w-full items-center justify-between text-left"
+              >
+                <div>
+                  <p className="text-sm font-medium text-neutral-400">Preview employee views</p>
+                  <p className="text-xs italic text-neutral-600">
+                    See what each view looks like for employees before assigning it to a category.
+                  </p>
+                </div>
+                <ChevronDown
+                  className={`h-4 w-4 text-neutral-500 transition-transform duration-200 ${previewOpen ? "rotate-180" : ""}`}
+                />
+              </button>
+
+              {previewOpen && (
+                <div className="mt-4">
+                  {/* Tab selector */}
+                  <div className="mb-4 flex gap-2">
+                    <button
+                      onClick={() => setPreviewView('weekly')}
+                      className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                        previewView === 'weekly'
+                          ? "border-blue-700 bg-blue-950/50 text-blue-400"
+                          : "border-neutral-700 bg-neutral-800 text-neutral-500 hover:text-neutral-300"
+                      }`}
+                    >
+                      Weekly Schedule
+                    </button>
+                    <button
+                      onClick={() => setPreviewView('today_only')}
+                      className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                        previewView === 'today_only'
+                          ? "border-blue-700 bg-blue-950/50 text-blue-400"
+                          : "border-neutral-700 bg-neutral-800 text-neutral-500 hover:text-neutral-300"
+                      }`}
+                    >
+                      Clock In/Out
+                    </button>
+                  </div>
+
+                  {/* Mockup frame */}
+                  <div className="overflow-hidden rounded-xl border border-neutral-700 bg-neutral-950">
+                    {previewView === 'weekly' ? (
+                      <div className="p-4">
+                        <div className="mb-3 flex items-center justify-between">
+                          <div className="h-3 w-24 rounded bg-neutral-800" />
+                          <div className="flex gap-1">
+                            <div className="h-6 w-6 rounded bg-neutral-800" />
+                            <div className="h-6 w-16 rounded bg-neutral-800" />
+                            <div className="h-6 w-6 rounded bg-neutral-800" />
+                          </div>
+                        </div>
+                        <div className="space-y-1.5">
+                          {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((day) => (
+                            <div
+                              key={day}
+                              className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2"
+                            >
+                              <span className="w-7 text-xs text-neutral-500">{day}</span>
+                              <div className="h-2 w-14 rounded bg-neutral-800" />
+                              <span className="text-xs text-neutral-700">—</span>
+                              <div className="h-2 w-14 rounded bg-neutral-800" />
+                              <div className="ml-auto h-5 w-10 rounded bg-neutral-800" />
+                            </div>
+                          ))}
+                        </div>
+                        <p className="mt-2 text-center text-xs text-neutral-600">Weekly Schedule — 7-day grid with time pickers</p>
+                      </div>
+                    ) : (
+                      <div className="p-4">
+                        <div className="mb-4 text-center">
+                          <div className="mx-auto mb-1 h-3 w-32 rounded bg-neutral-800" />
+                          <div className="mx-auto h-6 w-24 rounded bg-neutral-800" />
+                        </div>
+                        <div className="mx-auto mb-4 flex w-fit items-center gap-1 rounded-full border border-neutral-800 bg-neutral-900 px-4 py-1">
+                          <div className="h-2 w-16 rounded bg-neutral-800" />
+                        </div>
+                        <div className="flex justify-center gap-3">
+                          <div className="flex h-20 w-28 flex-col items-center justify-center gap-1 rounded-2xl border border-green-900/40 bg-green-950/30">
+                            <div className="h-5 w-5 rounded-full bg-green-900/50" />
+                            <span className="text-xs text-green-700">Clock In</span>
+                          </div>
+                          <div className="flex h-20 w-28 flex-col items-center justify-center gap-1 rounded-2xl border border-neutral-800 bg-neutral-900/50 opacity-40">
+                            <div className="h-5 w-5 rounded-full bg-neutral-800" />
+                            <span className="text-xs text-neutral-600">Clock Out</span>
+                          </div>
+                        </div>
+                        <p className="mt-3 text-center text-xs text-neutral-600">Clock In/Out — today only, two big action buttons</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
           </motion.div>
 
           {/* Employees Section */}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -38,8 +38,11 @@ export interface EmployeeCategory {
   id: string;
   client_id: string;
   name: string;
+  dashboard_view: 'weekly' | 'today_only';
   created_at: string;
 }
+
+export type DashboardView = 'weekly' | 'today_only';
 
 /**
  * Employee entity

--- a/supabase/migrations/20260501_add_dashboard_view_to_categories.sql
+++ b/supabase/migrations/20260501_add_dashboard_view_to_categories.sql
@@ -1,0 +1,15 @@
+-- Determines which employee UI is shown to employees in this category.
+-- 'weekly'     = 7-day grid timesheet (default)
+-- 'today_only' = clock in / clock out (today only, two buttons)
+ALTER TABLE employee_categories
+  ADD COLUMN dashboard_view TEXT NOT NULL DEFAULT 'weekly'
+    CHECK (dashboard_view IN ('weekly', 'today_only'));
+
+-- Preserve existing behaviour: trimsfresh's 'Fruit' category gets today_only automatically.
+-- This mirrors what was previously hardcoded in the login page (categoryName === "Fruit").
+UPDATE employee_categories ec
+SET dashboard_view = 'today_only'
+FROM clients c
+WHERE ec.client_id = c.id
+  AND c.subdomain = 'trimsfresh'
+  AND ec.name = 'Fruit';


### PR DESCRIPTION
# feat: configurable dashboard views per employee category

## Why

The employee dashboard view was hardcoded in the login page with a magic string check:

```typescript
if (categoryName === "Fruit") {
  router.push("/client/employee/clock");
} else {
  router.push("/client/employee/dashboard");
}
```

This was built for trimsfresh's fruit pickers who needed a simpler clock in/out interface instead of the full weekly timesheet grid. The problem: it was tied to the literal category name `"Fruit"` — any other client who happened to name a category "Fruit" would silently get the wrong dashboard. There was also no way for a manager to see or change this behaviour without a code deploy.

---

## What changed

### Database

Added `dashboard_view TEXT NOT NULL DEFAULT 'weekly'` to the `employee_categories` table with a check constraint enforcing `'weekly' | 'today_only'`.

Migration applied: `supabase/migrations/20260501_add_dashboard_view_to_categories.sql`

The migration also included a targeted `UPDATE` to preserve trimsfresh's existing behaviour — their Fruit category was automatically set to `today_only` as part of the migration, so no employees were disrupted on deploy.

### API

- `GET /api/client/categories` — returns `dashboard_view` per category
- `POST /api/client/categories` — accepts optional `dashboardView` on creation
- `PUT /api/client/categories/[id]` — now supports partial updates (rename, view change, or both in one call)
- `GET /api/client/auth/employee/me` — returns `dashboardView` field instead of just `categoryName`

### Login routing

Replaced the hardcoded `categoryName === "Fruit"` check with `dashboardView === 'today_only'`. Routing is now driven entirely by the database value.

### Settings UI

**Inline view toggle:** Each category row now has a segmented **Weekly Schedule / Clock In/Out** control. Clicking auto-saves with no extra confirmation needed. The active segment is highlighted and the control disables while saving.

**Preview panel:** A collapsible "Preview employee views" section at the bottom of the Categories card shows static wireframe mockups of both views, so managers can see exactly what employees will see before making changes.

---

## How it works now

1. Manager opens Settings → Categories
2. Each row shows the current view assignment — toggle between **Weekly Schedule** and **Clock In/Out**
3. Saving fires `PUT /api/client/categories/[id]` and re-fetches the list
4. On employee login, `/me` returns the category's `dashboard_view`
5. Login routes to `/client/employee/clock` for `today_only`, `/client/employee/dashboard` for `weekly`

Any client, any category name — fully configurable without touching code.

---

## Files changed

| File | Change |
|---|---|
| `supabase/migrations/20260501_add_dashboard_view_to_categories.sql` | New migration — adds column, seeds trimsfresh Fruit to `today_only` |
| `src/types/database.ts` | `EmployeeCategory` gets `dashboard_view` + new `DashboardView` union type |
| `src/app/api/client/categories/route.ts` | GET + POST handle `dashboard_view` |
| `src/app/api/client/categories/[id]/route.ts` | PUT supports partial updates with `dashboardView` |
| `src/app/api/client/auth/employee/me/route.ts` | Selects and returns `dashboardView` |
| `src/app/client/employee/login/page.tsx` | Routes on `dashboardView`, removes hardcoded string check |
| `src/app/client/manager/settings/page.tsx` | Inline toggle + preview panel in Categories section |


<img width="966" height="307" alt="Screenshot 2026-05-01 at 11 06 18 pm" src="https://github.com/user-attachments/assets/1532a4eb-bf5d-497b-b86c-f9f17d1103ac" />

<img width="1051" height="732" alt="Screenshot 2026-05-01 at 11 06 04 pm" src="https://github.com/user-attachments/assets/2dc47dd5-3e2d-4d53-9a90-81818af0b344" />
<img width="1009" height="864" alt="Screenshot 2026-05-01 at 11 06 12 pm" src="https://github.com/user-attachments/assets/e9430007-eaa2-41b9-9d23-0dc332206043" />

