### PR TITLE
Rounding clock in setting added

### DIFF
--- a/src/app/api/client/categories/[id]/route.ts
+++ b/src/app/api/client/categories/[id]/route.ts
@@ -35,10 +35,10 @@ export async function PUT(
     const { supabase, clientId } = ctx;
     const { id } = await params;
 
-    const body = (await request.json()) as { name?: string; dashboardView?: string };
+    const body = (await request.json()) as { name?: string; dashboardView?: string; roundingMinutes?: number };
     const { name } = body;
 
-    const updatePayload: Record<string, string> = {};
+    const updatePayload: Record<string, string | number> = {};
 
     if (name !== undefined) {
       if (!name.trim()) {
@@ -58,6 +58,17 @@ export async function PUT(
         );
       }
       updatePayload.dashboard_view = body.dashboardView;
+    }
+
+    if (body.roundingMinutes !== undefined) {
+      const allowed = [0, 5, 10, 15, 30];
+      if (!allowed.includes(body.roundingMinutes)) {
+        return NextResponse.json(
+          { error: "roundingMinutes must be 0, 5, 10, 15, or 30" },
+          { status: 400 },
+        );
+      }
+      updatePayload.clock_in_rounding_minutes = body.roundingMinutes;
     }
 
     if (Object.keys(updatePayload).length === 0) {

--- a/src/app/api/client/categories/route.ts
+++ b/src/app/api/client/categories/route.ts
@@ -45,6 +45,7 @@ export async function GET(request: NextRequest) {
       client_id: cat.client_id,
       name: cat.name,
       dashboard_view: (cat.dashboard_view ?? 'weekly') as 'weekly' | 'today_only',
+      clock_in_rounding_minutes: (cat.clock_in_rounding_minutes as number | undefined) ?? 0,
       created_at: cat.created_at,
       employee_count: Array.isArray(cat.employees) ? cat.employees.length : 0,
     }));

--- a/src/app/api/client/timesheets/route.ts
+++ b/src/app/api/client/timesheets/route.ts
@@ -10,6 +10,21 @@ import { getSubdomainFromRequest } from "@/lib/subdomain";
 
 type SessionType = "manager" | "employee" | null;
 
+// Rounds a "HH:MM:SS" time string up to the next interval boundary.
+// e.g. "09:03:00" with 15 → "09:15:00". Already-on-boundary times are unchanged.
+function applyClockInRounding(time: string, intervalMinutes: number): string {
+  if (intervalMinutes === 0) return time;
+  const parts = time.split(":").map(Number);
+  const h = parts[0] ?? 0;
+  const m = parts[1] ?? 0;
+  const s = parts[2] ?? 0;
+  const totalMinutes = h * 60 + m;
+  const rounded = Math.ceil(totalMinutes / intervalMinutes) * intervalMinutes;
+  const rh = Math.floor(rounded / 60) % 24;
+  const rm = rounded % 60;
+  return `${String(rh).padStart(2, "0")}:${String(rm).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
 function getClientSession(request: NextRequest): {
   type: SessionType;
   clientId: string | null;
@@ -166,7 +181,7 @@ export async function POST(request: NextRequest) {
 
     const { data: employee } = await supabase
       .from("employees")
-      .select("client_id")
+      .select("client_id, category:employee_categories(clock_in_rounding_minutes)")
       .eq("id", employeeId)
       .single();
 
@@ -189,6 +204,10 @@ export async function POST(request: NextRequest) {
         { status: 401 },
       );
     }
+
+    const roundingMinutes =
+      (employee.category as { clock_in_rounding_minutes?: number } | null)
+        ?.clock_in_rounding_minutes ?? 0;
 
     const { data: existing } = await supabase
       .from("timesheets")
@@ -248,13 +267,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const roundedStartTime = applyClockInRounding(startTime, roundingMinutes);
+
     const { data: timesheet, error } = await supabase
       .from("timesheets")
       .insert({
         employee_id: employeeId,
         client_id: employee.client_id,
         work_date: workDate,
-        start_time: startTime,
+        start_time: roundedStartTime,
         end_time: endTime ?? null,
         notes: notes ?? null,
       })

--- a/src/app/api/client/timesheets/route.ts
+++ b/src/app/api/client/timesheets/route.ts
@@ -12,7 +12,7 @@ type SessionType = "manager" | "employee" | null;
 
 // Rounds a "HH:MM:SS" time string up to the next interval boundary.
 // e.g. "09:03:00" with 15 → "09:15:00". Already-on-boundary times are unchanged.
-function applyClockInRounding(time: string, intervalMinutes: number): string {
+function roundTime(time: string, intervalMinutes: number): string {
   if (intervalMinutes === 0) return time;
   const parts = time.split(":").map(Number);
   const h = parts[0] ?? 0;
@@ -218,7 +218,9 @@ export async function POST(request: NextRequest) {
 
     if (existing) {
       const newStartTime = startTime ?? existing.start_time;
-      const newEndTime = endTime ?? existing.end_time;
+      const newEndTime = typeof endTime === "string"
+        ? roundTime(endTime, roundingMinutes)
+        : (endTime ?? existing.end_time);
       const timesChanged =
         newStartTime !== existing.start_time || newEndTime !== existing.end_time;
 
@@ -267,7 +269,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const roundedStartTime = applyClockInRounding(startTime, roundingMinutes);
+    const roundedStartTime = roundTime(startTime, roundingMinutes);
 
     const { data: timesheet, error } = await supabase
       .from("timesheets")
@@ -276,7 +278,7 @@ export async function POST(request: NextRequest) {
         client_id: employee.client_id,
         work_date: workDate,
         start_time: roundedStartTime,
-        end_time: endTime ?? null,
+        end_time: typeof endTime === "string" ? roundTime(endTime, roundingMinutes) : null,
         notes: notes ?? null,
       })
       .select()

--- a/src/app/client/employee/clock/page.tsx
+++ b/src/app/client/employee/clock/page.tsx
@@ -92,7 +92,7 @@ export default function FruitClockPage() {
     const res = await fetch("/api/client/timesheets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ employeeId, workDate: today, startTime: `${clockState.startTime}:00`, endTime: `${now}:00` }),
+      body: JSON.stringify({ employeeId, workDate: today, endTime: `${now}:00` }),
     });
     if (!res.ok) {
       const json = await res.json() as { error?: string };

--- a/src/app/client/manager/settings/page.tsx
+++ b/src/app/client/manager/settings/page.tsx
@@ -20,7 +20,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Settings, ArrowLeft, Save, Trash2, Search, Users, Clock, Tag, Pencil, Check, X, ChevronDown } from "lucide-react";
+import { Settings, ArrowLeft, Save, Trash2, Search, Users, Clock, Tag, Pencil, Check, X, ChevronDown, Settings2 } from "lucide-react";
 import type { Employee, EmployeeCategory } from "@/types/database";
 import { EmployeeDialog } from "./components/EmployeeDialog";
 import { motion } from "framer-motion";
@@ -46,6 +46,9 @@ export default function ManagerSettingsPage() {
   const [addingCategory, setAddingCategory] = useState(false);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const [settingsOpenId, setSettingsOpenId] = useState<string | null>(null);
+  // rounding in minutes per category (0 = no rounding); backend not connected yet
+  const [categoryRounding, setCategoryRounding] = useState<Record<string, number>>({});
 
   // Bulk assign state
   const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<Set<string>>(new Set());
@@ -549,37 +552,7 @@ export default function ManagerSettingsPage() {
                         </span>
                       </div>
 
-                      {/* Inline segmented view toggle */}
-                      <div className="mx-3 flex shrink-0 items-center rounded-lg border border-neutral-700 bg-neutral-800 p-0.5">
-                        <button
-                          disabled={updatingViewId === cat.id}
-                          onClick={() => {
-                            if (cat.dashboard_view !== 'weekly') void handleUpdateDashboardView(cat.id, 'weekly');
-                          }}
-                          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                            cat.dashboard_view === 'weekly'
-                              ? "bg-neutral-600 text-neutral-100 shadow-sm"
-                              : "text-neutral-500 hover:text-neutral-300"
-                          }`}
-                        >
-                          Weekly Schedule
-                        </button>
-                        <button
-                          disabled={updatingViewId === cat.id}
-                          onClick={() => {
-                            if (cat.dashboard_view !== 'today_only') void handleUpdateDashboardView(cat.id, 'today_only');
-                          }}
-                          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                            cat.dashboard_view === 'today_only'
-                              ? "bg-neutral-600 text-neutral-100 shadow-sm"
-                              : "text-neutral-500 hover:text-neutral-300"
-                          }`}
-                        >
-                          Clock In/Out
-                        </button>
-                      </div>
-
-                      {/* Rename + Delete actions */}
+                      {/* Rename + Delete + Settings actions */}
                       <div className="flex shrink-0 gap-2">
                         <button
                           onClick={() => { setRenamingId(cat.id); setRenameValue(cat.name); }}
@@ -587,6 +560,88 @@ export default function ManagerSettingsPage() {
                         >
                           <Pencil className="h-3 w-3" /> Rename
                         </button>
+                        <div className="relative">
+                          <button
+                            onClick={() => setSettingsOpenId(settingsOpenId === cat.id ? null : cat.id)}
+                            className={`flex items-center gap-1 rounded-lg border px-2 py-1 text-xs transition-colors ${
+                              settingsOpenId === cat.id
+                                ? "border-blue-700 bg-blue-950/50 text-blue-400"
+                                : "border-neutral-700 bg-neutral-800 text-neutral-400 hover:border-neutral-600 hover:text-neutral-200"
+                            }`}
+                          >
+                            <Settings2 className="h-3 w-3" /> Settings
+                          </button>
+                          {settingsOpenId === cat.id && (
+                            <>
+                              <div
+                                className="fixed inset-0 z-10"
+                                onClick={() => setSettingsOpenId(null)}
+                              />
+                              <div className="absolute right-0 top-full z-20 mt-1.5 w-64 rounded-xl border border-neutral-700 bg-neutral-900 p-3 shadow-xl shadow-black/60">
+                                <p className="mb-2 text-xs font-medium text-neutral-400">Employee Dashboard View</p>
+                                <div className="flex rounded-lg border border-neutral-700 bg-neutral-800 p-0.5">
+                                  <button
+                                    disabled={updatingViewId === cat.id}
+                                    onClick={() => {
+                                      if (cat.dashboard_view !== 'weekly') void handleUpdateDashboardView(cat.id, 'weekly');
+                                    }}
+                                    className={`flex-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                                      cat.dashboard_view === 'weekly'
+                                        ? "bg-neutral-600 text-neutral-100 shadow-sm"
+                                        : "text-neutral-500 hover:text-neutral-300"
+                                    }`}
+                                  >
+                                    Weekly
+                                  </button>
+                                  <button
+                                    disabled={updatingViewId === cat.id}
+                                    onClick={() => {
+                                      if (cat.dashboard_view !== 'today_only') void handleUpdateDashboardView(cat.id, 'today_only');
+                                    }}
+                                    className={`flex-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                                      cat.dashboard_view === 'today_only'
+                                        ? "bg-neutral-600 text-neutral-100 shadow-sm"
+                                        : "text-neutral-500 hover:text-neutral-300"
+                                    }`}
+                                  >
+                                    Clock In/Out
+                                  </button>
+                                </div>
+
+                                {cat.dashboard_view === 'today_only' && (
+                                  <div className="mt-3 border-t border-neutral-800 pt-3">
+                                    <p className="mb-2 text-xs font-medium text-neutral-400">Clock-in Rounding</p>
+                                    <div className="grid grid-cols-5 gap-1">
+                                      {[0, 5, 10, 15, 30].map((mins) => {
+                                        const active = (categoryRounding[cat.id] ?? 0) === mins;
+                                        return (
+                                          <button
+                                            key={mins}
+                                            onClick={() => setCategoryRounding((prev) => ({ ...prev, [cat.id]: mins }))}
+                                            className={`rounded-md py-1 text-xs font-medium transition-colors ${
+                                              active
+                                                ? "bg-blue-600 text-white"
+                                                : "bg-neutral-800 text-neutral-500 hover:bg-neutral-700 hover:text-neutral-300"
+                                            }`}
+                                          >
+                                            {mins === 0 ? "Off" : `${mins}m`}
+                                          </button>
+                                        );
+                                      })}
+                                    </div>
+                                    <p className="mt-2 text-xs text-neutral-600">
+                                      Rounds clock-in up to the next interval — e.g. 9:03 → 9:15 with 15m rounding.
+                                    </p>
+                                  </div>
+                                )}
+
+                                <p className="mt-2 text-xs text-neutral-600">
+                                  Controls what employees in this category see on their dashboard.
+                                </p>
+                              </div>
+                            </>
+                          )}
+                        </div>
                         <button
                           onClick={() => void handleDeleteCategory(cat.id, cat.name)}
                           className="flex items-center gap-1 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-1 text-xs text-red-400 hover:border-red-900 hover:bg-red-900/20"

--- a/src/app/client/manager/settings/page.tsx
+++ b/src/app/client/manager/settings/page.tsx
@@ -629,9 +629,21 @@ export default function ManagerSettingsPage() {
                                         );
                                       })}
                                     </div>
-                                    <p className="mt-2 text-xs text-neutral-600">
-                                      Rounds clock-in up to the next interval — e.g. 9:03 → 9:15 with 15m rounding.
-                                    </p>
+                                    {(() => {
+                                      const selected = categoryRounding[cat.id] ?? 0;
+                                      if (selected === 0) {
+                                        return <p className="mt-2 text-xs text-neutral-600">Times are recorded exactly as clocked.</p>;
+                                      }
+                                      const inputMins = 9 * 60 + 3;
+                                      const roundedMins = Math.ceil(inputMins / selected) * selected;
+                                      const h = Math.floor(roundedMins / 60);
+                                      const m = String(roundedMins % 60).padStart(2, "0");
+                                      return (
+                                        <p className="mt-2 text-xs text-neutral-600">
+                                          e.g. 9:03 → {h}:{m} with {selected}m rounding.
+                                        </p>
+                                      );
+                                    })()}
                                   </div>
                                 )}
 

--- a/src/app/client/manager/settings/page.tsx
+++ b/src/app/client/manager/settings/page.tsx
@@ -94,10 +94,13 @@ export default function ManagerSettingsPage() {
       if (response.ok) {
         setCategories(data.categories ?? []);
         const counts: Record<string, number> = {};
+        const rounding: Record<string, number> = {};
         for (const cat of data.categories ?? []) {
           counts[cat.id] = cat.employee_count;
+          rounding[cat.id] = cat.clock_in_rounding_minutes;
         }
         setCategoryEmployeeCounts(counts);
+        setCategoryRounding(rounding);
       }
     } catch (error) {
       console.error("Error fetching categories:", error);
@@ -295,6 +298,28 @@ export default function ManagerSettingsPage() {
       console.error("Error updating dashboard view:", error);
     } finally {
       setUpdatingViewId(null);
+    }
+  };
+
+  /**
+   * Update clock-in rounding for a category (optimistic, auto-saves on change)
+   */
+  const handleUpdateRounding = async (id: string, minutes: number) => {
+    setCategoryRounding((prev) => ({ ...prev, [id]: minutes }));
+    try {
+      const response = await fetch(`/api/client/categories/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ roundingMinutes: minutes }),
+      });
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string };
+        alert(data.error ?? "Failed to update rounding");
+        await fetchCategories();
+      }
+    } catch (error) {
+      console.error("Error updating rounding:", error);
+      await fetchCategories();
     }
   };
 
@@ -617,7 +642,7 @@ export default function ManagerSettingsPage() {
                                         return (
                                           <button
                                             key={mins}
-                                            onClick={() => setCategoryRounding((prev) => ({ ...prev, [cat.id]: mins }))}
+                                            onClick={() => void handleUpdateRounding(cat.id, mins)}
                                             className={`rounded-md py-1 text-xs font-medium transition-colors ${
                                               active
                                                 ? "bg-blue-600 text-white"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -39,6 +39,7 @@ export interface EmployeeCategory {
   client_id: string;
   name: string;
   dashboard_view: 'weekly' | 'today_only';
+  clock_in_rounding_minutes: number;
   created_at: string;
 }
 

--- a/supabase/migrations/20260515_add_clock_in_rounding_to_categories.sql
+++ b/supabase/migrations/20260515_add_clock_in_rounding_to_categories.sql
@@ -1,0 +1,6 @@
+-- Clock-in rounding per category (applies to 'today_only' / Clock In/Out view).
+-- 0 = no rounding (default). Other valid values: 5, 10, 15, 30 (minutes).
+-- The API enforces the allowed values; the CHECK is belt-and-suspenders.
+ALTER TABLE employee_categories
+  ADD COLUMN clock_in_rounding_minutes INTEGER NOT NULL DEFAULT 0
+    CHECK (clock_in_rounding_minutes IN (0, 5, 10, 15, 30));


### PR DESCRIPTION
Category selection for weekly vs clock in has now moved to a settings button in-between rename and delete. Once clicked you get the choice of weekly or clock-in/out. Selecting Clock-in/out comes with a rounding setting, allowing for managers to add a rounding value to that categories clock in calculations. For example, if a manager selects 5 mins, and they clock in at 9:03, the saved time will be 9:05.

Currently, rounding only works for the clock-in style. 