### PR TITLE
Edit button and New reports put into the system

### DIFF
--- a/src/app/api/client/timesheets/route.ts
+++ b/src/app/api/client/timesheets/route.ts
@@ -279,6 +279,8 @@ export async function POST(request: NextRequest) {
         work_date: workDate,
         start_time: roundedStartTime,
         end_time: typeof endTime === "string" ? roundTime(endTime, roundingMinutes) : null,
+        original_start_time: startTime,
+        original_end_time: typeof endTime === "string" ? endTime : null,
         notes: notes ?? null,
       })
       .select()

--- a/src/app/api/client/timesheets/route.ts
+++ b/src/app/api/client/timesheets/route.ts
@@ -211,7 +211,7 @@ export async function POST(request: NextRequest) {
 
     const { data: existing } = await supabase
       .from("timesheets")
-      .select("id, start_time, end_time")
+      .select("id, start_time, end_time, original_end_time")
       .eq("employee_id", employeeId)
       .eq("work_date", workDate)
       .single();
@@ -229,6 +229,10 @@ export async function POST(request: NextRequest) {
         end_time: newEndTime,
         notes: notes ?? null,
       };
+      // Capture original end time on first clock-out only; don't overwrite on manager edits
+      if (existing.end_time === null && typeof endTime === "string") {
+        updateData.original_end_time = endTime;
+      }
       if (timesChanged) updateData.break_minutes = null;
 
       const { data: timesheet, error } = await supabase

--- a/src/app/client/manager/employee/[employeeId]/components/EditTimesheetDialog.tsx
+++ b/src/app/client/manager/employee/[employeeId]/components/EditTimesheetDialog.tsx
@@ -143,9 +143,9 @@ export function EditTimesheetDialog({
       <DialogContent className="border-neutral-700 bg-neutral-800 text-white sm:max-w-[500px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Edit Timesheet</DialogTitle>
+            <DialogTitle>{initialStartTime ? "Edit Timesheet" : "Add Hours"}</DialogTitle>
             <DialogDescription className="text-neutral-400">
-              Update start and end times for {new Date(workDate).toLocaleDateString()}
+              {initialStartTime ? "Update" : "Add"} start and end times for {new Date(workDate).toLocaleDateString()}
             </DialogDescription>
           </DialogHeader>
 
@@ -195,7 +195,7 @@ export function EditTimesheetDialog({
                   Updating...
                 </>
               ) : (
-                "Save Changes"
+                initialStartTime ? "Save Changes" : "Add Hours"
               )}
             </Button>
           </DialogFooter>

--- a/src/app/client/manager/employee/[employeeId]/page.tsx
+++ b/src/app/client/manager/employee/[employeeId]/page.tsx
@@ -366,7 +366,19 @@ function EmployeeDetailContent() {
                         </motion.div>
                       </div>
                     ) : (
-                      <p className="text-sm text-neutral-500">No hours logged</p>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm text-neutral-500">No hours logged</p>
+                        <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditingDay(day)}
+                            className="border-neutral-700 bg-neutral-800/50 backdrop-blur-sm transition-all hover:border-green-500/50 hover:bg-green-500/10 hover:text-green-400"
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </motion.div>
+                      </div>
                     )}
                   </div>
 

--- a/src/components/PrintSelectModal.tsx
+++ b/src/components/PrintSelectModal.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { printWeekSummary, printDayBreakdown } from "@/lib/csvExport";
+import { printWeekSummary, printDayBreakdown, printClockTimesReport } from "@/lib/csvExport";
+import type { ClockTimesEntry } from "@/lib/csvExport";
 import type { Employee, TimesheetWithEmployee } from "@/types/database";
 import { format, getDay } from "date-fns";
 import { isPublicHoliday } from "@/lib/holidays";
@@ -36,7 +37,7 @@ export function PrintSelectModal({
   weekStart,
   weekEnd,
 }: PrintSelectModalProps) {
-  const [selected, setSelected] = useState<"week-summary" | "day-breakdown" | null>(null);
+  const [selected, setSelected] = useState<"week-summary" | "day-breakdown" | "clock-times" | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
   const categories = Array.from(
@@ -80,7 +81,7 @@ export function PrintSelectModal({
       }).filter((e) => e.totalHours > 0);
 
       printWeekSummary({ employees: empData, weekEndingDate: weekEnd });
-    } else {
+    } else if (selected === "day-breakdown") {
       const empData = filteredEmployees.map((emp) => {
         const empTs = timesheets.filter((ts) => ts.employee_id === emp.id);
         const dailyHours: Record<string, number> = {};
@@ -92,6 +93,24 @@ export function PrintSelectModal({
       }).filter((e) => Object.keys(e.dailyHours).length > 0);
 
       printDayBreakdown({ employees: empData, weekStart, weekEnd });
+    } else {
+      const empById = new Map(filteredEmployees.map((e) => [e.id, e]));
+      const entries: ClockTimesEntry[] = timesheets
+        .filter((ts) => empById.has(ts.employee_id))
+        .map((ts) => {
+          const emp = empById.get(ts.employee_id)!;
+          return {
+            date: format(new Date(ts.work_date), "yyyy-MM-dd"),
+            firstName: emp.first_name,
+            lastName: emp.last_name,
+            categoryName: emp.category?.name ?? "",
+            startTime: ts.start_time,
+            endTime: ts.end_time ?? null,
+            totalHours: parseFloat(ts.total_hours.toString()),
+          };
+        });
+
+      printClockTimesReport({ entries, startDate: weekStart, endDate: weekEnd });
     }
 
     onClose();
@@ -123,7 +142,7 @@ export function PrintSelectModal({
             </div>
 
             <div className="space-y-3">
-              {(["week-summary", "day-breakdown"] as const).map((opt) => (
+              {(["week-summary", "day-breakdown", "clock-times"] as const).map((opt) => (
                 <button
                   key={opt}
                   onClick={() => setSelected(opt)}
@@ -136,12 +155,14 @@ export function PrintSelectModal({
                   <FileText className="h-5 w-5 shrink-0 text-primary" />
                   <div>
                     <p className="font-medium">
-                      {opt === "week-summary" ? "Week Summary" : "Day Breakdown"}
+                      {opt === "week-summary" ? "Week Summary" : opt === "day-breakdown" ? "Day Breakdown" : "Clock Times"}
                     </p>
                     <p className="text-xs text-neutral-400">
                       {opt === "week-summary"
                         ? "One row per employee — weekly hour totals"
-                        : "One row per employee — hours per day across the week"}
+                        : opt === "day-breakdown"
+                          ? "One row per employee — hours per day across the week"
+                          : "One row per shift — exact clock-in and clock-out times"}
                     </p>
                   </div>
                 </button>

--- a/src/components/PrintSelectModal.tsx
+++ b/src/components/PrintSelectModal.tsx
@@ -104,8 +104,8 @@ export function PrintSelectModal({
             firstName: emp.first_name,
             lastName: emp.last_name,
             categoryName: emp.category?.name ?? "",
-            startTime: ts.start_time,
-            endTime: ts.end_time ?? null,
+            startTime: ts.original_start_time ?? ts.start_time,
+            endTime: ts.original_end_time ?? ts.end_time ?? null,
             totalHours: parseFloat(ts.total_hours.toString()),
           };
         });

--- a/src/components/TimeInput.tsx
+++ b/src/components/TimeInput.tsx
@@ -1,12 +1,3 @@
-/**
- * TimeInput Component
- * Specialized input for time entry in HH:MM format
- * Features:
- * - Auto-formats as user types
- * - Only allows numeric input
- * - Displays clock icon
- * - Optional label
- */
 "use client";
 
 import { Input } from "@/components/ui/input";
@@ -29,39 +20,63 @@ export function TimeInput({
   placeholder = "--:--",
   label,
 }: TimeInputProps) {
-  /**
-   * Handle input change
-   * Strips non-numeric characters and auto-formats to HH:MM
-   */
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // Remove all non-numeric characters
-    let val = e.target.value.replace(/[^0-9]/g, "");
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // When value is exactly "HH:" and user presses Backspace, drop the colon.
+    // Without this, onChange would immediately re-add it and keep the cursor stuck.
+    if (e.key === "Backspace" && value.length === 3 && value[2] === ":") {
+      e.preventDefault();
+      onChange(value.slice(0, 2));
+    }
+  };
 
-    // Auto-format: insert colon after 2 digits
-    if (val.length >= 2) {
-      val = val.slice(0, 2) + ":" + val.slice(2, 4);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawInput = e.target.value;
+    let digits = rawInput.replace(/[^0-9]/g, "");
+
+    // Raw input ends with ":" means user just deleted the last minute digit.
+    // Return bare hour digits (no colon) so the formatter doesn't immediately
+    // re-insert the colon and trap the cursor.
+    if (rawInput.endsWith(":")) {
+      onChange(digits.slice(0, 2));
+      return;
     }
 
-    onChange(val);
+    // Clamp hours to 0–23
+    if (digits.length >= 2) {
+      const hours = parseInt(digits.slice(0, 2), 10);
+      if (hours > 23) {
+        digits = "23" + digits.slice(2);
+      }
+    }
+
+    // Clamp minutes to 0–59
+    if (digits.length >= 4) {
+      const minutes = parseInt(digits.slice(2, 4), 10);
+      if (minutes > 59) {
+        digits = digits.slice(0, 2) + "59";
+      }
+    }
+
+    // Auto-format: insert colon after 2 hour digits
+    if (digits.length >= 2) {
+      digits = digits.slice(0, 2) + ":" + digits.slice(2, 4);
+    }
+
+    onChange(digits);
   };
 
   return (
     <div className="space-y-2">
-      {/* Optional label */}
       {label && <label className="text-sm font-medium">{label}</label>}
-
-      {/* Input with clock icon */}
       <div className="relative">
-        {/* Clock icon positioned on the left */}
         <Clock className="absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2 text-neutral-400" />
-
-        {/* Time input field */}
         <Input
           type="text"
           value={value}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          maxLength={5} // HH:MM = 5 characters
+          maxLength={5}
           className="border-neutral-700 bg-neutral-800 pl-10"
         />
       </div>

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -510,6 +510,140 @@ export function printDayBreakdown({ employees, weekStart, weekEnd }: DayBreakdow
   setTimeout(() => { win.focus(); win.print(); win.close(); }, 300);
 }
 
+// ─── Clock Times Report ───────────────────────────────────────────────────────
+
+export interface ClockTimesEntry {
+  date: string; // ISO yyyy-MM-dd
+  firstName: string;
+  lastName: string;
+  categoryName: string;
+  startTime: string; // HH:MM:SS
+  endTime: string | null;
+  totalHours: number;
+}
+
+interface ClockTimesOptions {
+  entries: ClockTimesEntry[];
+  startDate: Date;
+  endDate: Date;
+}
+
+function formatTime12hr(time: string | null): string {
+  if (!time) return "—";
+  const parts = time.split(":").map(Number);
+  const h = parts[0] ?? 0;
+  const m = parts[1] ?? 0;
+  const period = h >= 12 ? "PM" : "AM";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return `${hour12}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+export function printClockTimesReport({ entries, startDate, endDate }: ClockTimesOptions): void {
+  const startLabel = formatDateAU(startDate);
+  const endLabel = formatDateAU(endDate);
+  const isSingleDay = startLabel === endLabel;
+  const title = isSingleDay ? `Clock Times - ${startLabel}` : `Clock Times - ${startLabel} to ${endLabel}`;
+
+  const win = window.open("", "_blank", "width=1000,height=700");
+  if (!win) { alert("Pop-ups are blocked. Please allow pop-ups for this site to use the print function."); return; }
+
+  const doc = win.document;
+  doc.title = title;
+
+  const style = doc.createElement("style");
+  style.textContent = `
+    @media print { @page { margin: 1cm; size: portrait; } body { margin: 0; } }
+    body { font-family: Arial, sans-serif; padding: 20px; color: #111; }
+    h1 { font-size: 18px; margin-bottom: 4px; }
+    p.subtitle { font-size: 13px; color: #555; margin: 0 0 16px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    th, td { border: 1px solid #ccc; padding: 7px 10px; text-align: left; font-size: 13px; }
+    th { background-color: #f0f0f0; font-weight: bold; }
+    tr:nth-child(even) { background-color: #f9f9f9; }
+    .center { text-align: center; }
+    .cat-header td { background-color: #e0e8f0; font-weight: bold; font-size: 13px; }
+    .no-data { text-align: center; color: #999; padding: 20px; }
+  `;
+  doc.head.appendChild(style);
+
+  const h1 = doc.createElement("h1");
+  h1.textContent = title;
+  doc.body.appendChild(h1);
+
+  const subtitle = doc.createElement("p");
+  subtitle.className = "subtitle";
+  subtitle.textContent = "Times shown are as recorded (after any rounding applied at clock-in).";
+  doc.body.appendChild(subtitle);
+
+  if (entries.length === 0) {
+    const p = doc.createElement("p");
+    p.className = "no-data";
+    p.textContent = "No timesheet entries for this period.";
+    doc.body.appendChild(p);
+    setTimeout(() => { win.focus(); win.print(); win.close(); }, 300);
+    return;
+  }
+
+  // Sort: category → employee last name → date
+  const sorted = [...entries].sort((a, b) => {
+    const catCmp = a.categoryName.localeCompare(b.categoryName);
+    if (catCmp !== 0) return catCmp;
+    const nameCmp = `${a.lastName}${a.firstName}`.localeCompare(`${b.lastName}${b.firstName}`);
+    if (nameCmp !== 0) return nameCmp;
+    return a.date.localeCompare(b.date);
+  });
+
+  const table = doc.createElement("table");
+  const thead = doc.createElement("thead");
+  const headerRow = doc.createElement("tr");
+  for (const label of ["Date", "Employee", "Category", "Clock In", "Clock Out", "Hours"]) {
+    const th = doc.createElement("th");
+    th.textContent = label;
+    if (label === "Clock In" || label === "Clock Out" || label === "Hours") th.className = "center";
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = doc.createElement("tbody");
+  let lastCat = "";
+  for (const entry of sorted) {
+    if (entry.categoryName !== lastCat) {
+      lastCat = entry.categoryName;
+      const catRow = doc.createElement("tr");
+      catRow.className = "cat-header";
+      const catCell = doc.createElement("td");
+      catCell.colSpan = 6;
+      catCell.textContent = entry.categoryName || "Uncategorised";
+      catRow.appendChild(catCell);
+      tbody.appendChild(catRow);
+    }
+
+    const tr = doc.createElement("tr");
+    const addCell = (text: string, center = false) => {
+      const td = doc.createElement("td");
+      if (center) td.className = "center";
+      td.textContent = text;
+      tr.appendChild(td);
+    };
+
+    const [y, mo, d] = entry.date.split("-");
+    const dateLabel = `${d}/${mo}/${y}`;
+
+    addCell(dateLabel ?? entry.date);
+    addCell(`${entry.firstName} ${entry.lastName}`);
+    addCell(entry.categoryName || "Uncategorised");
+    addCell(formatTime12hr(entry.startTime), true);
+    addCell(formatTime12hr(entry.endTime), true);
+    addCell(entry.endTime ? entry.totalHours.toFixed(2) : "—", true);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  doc.body.appendChild(table);
+
+  setTimeout(() => { win.focus(); win.print(); win.close(); }, 300);
+}
+
 // ─── Date Range Breakdown ─────────────────────────────────────────────────────
 
 interface DateRangeOptions {

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -572,7 +572,7 @@ export function printClockTimesReport({ entries, startDate, endDate }: ClockTime
 
   const subtitle = doc.createElement("p");
   subtitle.className = "subtitle";
-  subtitle.textContent = "Times shown are as recorded (after any rounding).";
+  subtitle.textContent = "Clock-in/out as punched where recorded; older entries may show rounded times.";
   doc.body.appendChild(subtitle);
 
   if (entries.length === 0) {

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -572,7 +572,7 @@ export function printClockTimesReport({ entries, startDate, endDate }: ClockTime
 
   const subtitle = doc.createElement("p");
   subtitle.className = "subtitle";
-  subtitle.textContent = "Times shown are as recorded (after any rounding applied at clock-in).";
+  subtitle.textContent = "Times shown are as recorded (after any rounding).";
   doc.body.appendChild(subtitle);
 
   if (entries.length === 0) {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -81,6 +81,8 @@ export interface Timesheet {
   end_time: string | null; // HH:MM:SS, null if employee has not yet clocked out
   break_minutes: number;
   total_hours: number;
+  original_start_time: string | null;
+  original_end_time: string | null;
   notes?: string;
   submitted_at: string;
   created_at: string;

--- a/supabase/migrations/20260529_timesheet_original_times.sql
+++ b/supabase/migrations/20260529_timesheet_original_times.sql
@@ -1,0 +1,6 @@
+-- Store original (pre-rounding) clock-in/out times so managers can view exact
+-- times vs. rounded times in reports. Only populated on initial employee clock-in;
+-- manager edits leave these columns unchanged.
+ALTER TABLE timesheets
+  ADD COLUMN original_start_time TEXT,
+  ADD COLUMN original_end_time TEXT;


### PR DESCRIPTION
Features: 
- Edit button on empty days — managers can now click an edit button on days with no hours logged from the employee detail view, not just days with existing timesheets
- Clock-in rounding per category — categories now have a configurable rounding interval (0, 5, 10, 15, 30 min); clock-in and clock-out times are rounded up to the next boundary on the backend at the time of submission
- Original times preserved — raw (pre-rounding) clock times are stored in new original_start_time / original_end_time columns so the audit trail is never lost
- "Clock Times" report — new print/export option showing one row per shift with exact (pre-rounding) clock-in and clock-out times
- Days worked column — week summary and day breakdown reports now include a "Days" column counting completed shifts

Bug fixes — corrected clock display in reports, fixed stuck colon when deleting in the time input, added clamping to the time input box, fixed start time display in manager view

DB migrations
20260515_add_clock_in_rounding_to_categories.sql — adds clock_in_rounding_minutes to employee_categories
20260529_timesheet_original_times.sql — adds original_start_time / original_end_time to timesheets